### PR TITLE
RFL-837: Support strftime-style date formats.

### DIFF
--- a/xtime/errors.go
+++ b/xtime/errors.go
@@ -3,6 +3,8 @@ package xtime
 import "errors"
 
 var (
-	ErrNotImplemented      = errors.New("xtime: not implemented")
-	ErrInvalidFormatString = errors.New("xtime: invalid format string")
+	ErrNotImplemented         = errors.New("xtime: not implemented")
+	ErrInvalidFormatString    = errors.New("xtime: invalid format string")
+	ErrFormatStringTooComplex = errors.New("xtime: format string is too complex to be parsed")
+	ErrInvalidTime            = errors.New("xtime: invalid time")
 )

--- a/xtime/errors.go
+++ b/xtime/errors.go
@@ -1,0 +1,8 @@
+package xtime
+
+import "errors"
+
+var (
+	ErrNotImplemented      = errors.New("xtime: not implemented")
+	ErrInvalidFormatString = errors.New("xtime: invalid format string")
+)

--- a/xtime/posix.go
+++ b/xtime/posix.go
@@ -1,0 +1,153 @@
+package xtime
+
+import (
+	"bytes"
+)
+
+const (
+	posixStateStr = iota
+	posixStateSpecifier
+)
+
+type posixBuffers []*bytes.Buffer
+
+func (p *posixBuffers) WriteRune(rs ...rune) {
+	switch len(rs) {
+	case 0:
+	case 1:
+		for _, buf := range *p {
+			buf.WriteRune(rs[0])
+		}
+	default:
+		pn := make(posixBuffers, len(*p)*len(rs))
+		for i, buf := range *p {
+			b := buf.Bytes()
+
+			for j, r := range rs {
+				idx := i*len(rs) + j
+
+				pn[idx] = bytes.NewBuffer(make([]byte, 0, len(b)))
+				pn[idx].Write(b)
+				pn[idx].WriteRune(r)
+			}
+		}
+
+		*p = pn
+	}
+}
+
+func (p *posixBuffers) WriteString(ss ...string) {
+	switch len(ss) {
+	case 0:
+	case 1:
+		for _, buf := range *p {
+			buf.WriteString(ss[0])
+		}
+	default:
+		pn := make(posixBuffers, len(*p)*len(ss))
+		for i, buf := range *p {
+			b := buf.Bytes()
+
+			for j, s := range ss {
+				idx := i*len(ss) + j
+
+				pn[idx] = bytes.NewBuffer(make([]byte, 0, len(b)))
+				pn[idx].Write(b)
+				pn[idx].WriteString(s)
+			}
+		}
+
+		*p = pn
+	}
+}
+
+func (p posixBuffers) Strings() []string {
+	r := make([]string, len(p))
+	for i, buf := range p {
+		r[i] = string(buf.Bytes())
+	}
+
+	return r
+}
+
+func FromPOSIX(format string) ([]string, error) {
+	bufs := &posixBuffers{&bytes.Buffer{}}
+	state := posixStateStr
+
+	for _, c := range format {
+		switch state {
+		case posixStateStr:
+			switch c {
+			case '%':
+				state = posixStateSpecifier
+			default:
+				bufs.WriteRune(c)
+			}
+		case posixStateSpecifier:
+			switch c {
+			case 'a', 'A':
+				bufs.WriteString("Mon", "Monday")
+			case 'b', 'B', 'h':
+				bufs.WriteString("Jan", "January")
+			case 'C':
+				// The century of the date. Very strange.
+				return nil, ErrNotImplemented
+			case 'd', 'e':
+				bufs.WriteString("2", "02")
+			case 'D':
+				bufs.WriteString("1/2/06", "1/02/06", "01/2/06", "01/02/06")
+			case 'H':
+				bufs.WriteString("15")
+			case 'I':
+				bufs.WriteString("3", "03")
+			case 'j':
+				// Day number of year.
+				return nil, ErrNotImplemented
+			case 'm':
+				bufs.WriteString("1", "01")
+			case 'M':
+				bufs.WriteString("4", "04")
+			case 'n', 't':
+				bufs.WriteString(" ", "\n", "\r", "\t", "\v")
+			case 'p':
+				bufs.WriteString("PM")
+			case 'r':
+				bufs.WriteString("3:4:5PM", "3:4:05PM", "3:04:5PM", "03:4:5PM", "3:04:05PM", "03:04:5PM", "03:04:05PM")
+			case 'R':
+				bufs.WriteString("15:4", "15:04")
+			case 'S':
+				bufs.WriteString("5", "05")
+			case 'T':
+				bufs.WriteString("15:4:5", "15:4:05", "15:04:5", "15:04:05")
+			case 'U':
+				// Week number of year (first day of the week is Sunday).
+				return nil, ErrNotImplemented
+			case 'w':
+				// Day number of week.
+				return nil, ErrNotImplemented
+			case 'W':
+				// Week number of year (first day of the week is Monday).
+				return nil, ErrNotImplemented
+			case 'c', 'x', 'X', 'E', 'O':
+				// Locale-specific formats.
+				return nil, ErrNotImplemented
+			case 'y':
+				bufs.WriteString("06")
+			case 'Y':
+				bufs.WriteString("2006")
+			case 'z':
+				// Time zone. Not supported by POSIX specification, but
+				// supported by Python. Seems fairly common.
+				bufs.WriteString("MST", "-0700")
+			case '%':
+				bufs.WriteRune('%')
+			default:
+				return nil, ErrInvalidFormatString
+			}
+
+			state = posixStateStr
+		}
+	}
+
+	return bufs.Strings(), nil
+}

--- a/xtime/posix.go
+++ b/xtime/posix.go
@@ -5,6 +5,8 @@ import (
 )
 
 const (
+	MaximumPOSIXBranches = 512
+
 	posixStateStr = iota
 	posixStateSpecifier
 )
@@ -90,12 +92,12 @@ func FromPOSIX(format string) ([]string, error) {
 			case 'b', 'B', 'h':
 				bufs.WriteString("Jan", "January")
 			case 'C':
-				// The century of the date. Very strange.
+				// The century of the date (e.g. 19 or 20). Very strange.
 				return nil, ErrNotImplemented
 			case 'd', 'e':
 				bufs.WriteString("2", "02")
 			case 'D':
-				bufs.WriteString("1/2/06", "1/02/06", "01/2/06", "01/02/06")
+				bufs.WriteString("1/2/06")
 			case 'H':
 				bufs.WriteString("15")
 			case 'I':
@@ -112,13 +114,13 @@ func FromPOSIX(format string) ([]string, error) {
 			case 'p':
 				bufs.WriteString("PM")
 			case 'r':
-				bufs.WriteString("3:4:5PM", "3:4:05PM", "3:04:5PM", "03:4:5PM", "3:04:05PM", "03:04:5PM", "03:04:05PM")
+				bufs.WriteString("3:4:5PM")
 			case 'R':
-				bufs.WriteString("15:4", "15:04")
+				bufs.WriteString("15:4")
 			case 'S':
 				bufs.WriteString("5", "05")
 			case 'T':
-				bufs.WriteString("15:4:5", "15:4:05", "15:04:5", "15:04:05")
+				bufs.WriteString("15:4:5")
 			case 'U':
 				// Week number of year (first day of the week is Sunday).
 				return nil, ErrNotImplemented
@@ -138,7 +140,7 @@ func FromPOSIX(format string) ([]string, error) {
 			case 'z':
 				// Time zone. Not supported by POSIX specification, but
 				// supported by Python. Seems fairly common.
-				bufs.WriteString("MST", "-0700")
+				bufs.WriteString("-0700", "-07:00")
 			case '%':
 				bufs.WriteRune('%')
 			default:
@@ -146,6 +148,10 @@ func FromPOSIX(format string) ([]string, error) {
 			}
 
 			state = posixStateStr
+		}
+
+		if len(*bufs) > MaximumPOSIXBranches {
+			return nil, ErrFormatStringTooComplex
 		}
 	}
 

--- a/xtime/posix_test.go
+++ b/xtime/posix_test.go
@@ -1,0 +1,30 @@
+package xtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromPOSIX(t *testing.T) {
+	valid := []struct {
+		Format    string
+		Candidate string
+		Expected  string
+	}{
+		{`%Y-%m-%dT%H:%M:%S%z`, "2017-04-13T00:31:00-0400", "2017-04-13T00:31:00-04:00"},
+		{`%a, %b %d, %Y %r %z`, "Thu, Apr 13, 2017 00:31:00AM -0400", "2017-04-13T00:31:00-04:00"},
+		{`%d/%m/%Y`, "05/04/2017", "2017-04-05T00:00:00Z"},
+	}
+
+	for _, v := range valid {
+		fs, err := FromPOSIX(v.Format)
+		assert.NoError(t, err)
+
+		p, err := Compile(fs).Parse(v.Candidate)
+		assert.NoError(t, err)
+
+		assert.Equal(t, v.Expected, p.Format(time.RFC3339))
+	}
+}

--- a/xtime/posix_test.go
+++ b/xtime/posix_test.go
@@ -15,7 +15,10 @@ func TestFromPOSIX(t *testing.T) {
 	}{
 		{`%Y-%m-%dT%H:%M:%S%z`, "2017-04-13T00:31:00-0400", "2017-04-13T00:31:00-04:00"},
 		{`%a, %b %d, %Y %r %z`, "Thu, Apr 13, 2017 00:31:00AM -0400", "2017-04-13T00:31:00-04:00"},
+		{`%a, %b %d, %Y %r %z`, "Thursday, April 13, 2017 00:31:00AM -04:00", "2017-04-13T00:31:00-04:00"},
 		{`%d/%m/%Y`, "05/04/2017", "2017-04-05T00:00:00Z"},
+		{`%d/%m/%Y`, "5/4/2017", "2017-04-05T00:00:00Z"},
+		{`%Y%m%d`, "20170405", "2017-04-05T00:00:00Z"},
 	}
 
 	for _, v := range valid {
@@ -25,6 +28,6 @@ func TestFromPOSIX(t *testing.T) {
 		p, err := Compile(fs).Parse(v.Candidate)
 		assert.NoError(t, err)
 
-		assert.Equal(t, v.Expected, p.Format(time.RFC3339))
+		assert.Equal(t, v.Expected, p.Format(time.RFC3339), "for format %s and candidate %s", v.Format, v.Candidate)
 	}
 }

--- a/xtime/xtime.go
+++ b/xtime/xtime.go
@@ -12,29 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// xtime is a time parser that parses the time without knowning the exact format.
+// Package xtime is a time parser that parses the time without knowning the
+// exact format.
 package xtime
 
 import (
-	"errors"
+	"fmt"
+	"regexp"
 	"strings"
 	"time"
-)
-
-var (
-	ErrUnknownTimeFormat = errors.New("Unknown time format")
+	"unicode"
+	"unicode/utf8"
 )
 
 // TimeFormats is a list of commonly seen time formats from log messages
-var TimeFormats []string = []string{
+var TimeFormats = []string{
 	"Mon Jan _2 15:04:05 2006",
-	"Mon Jan _2 15:04:05 MST 2006",
 	"Mon Jan 02 15:04:05 -0700 2006",
-	"02 Jan 06 15:04 MST",
+	"Mon Jan 02 15:04:05 -07:00 2006",
 	"02 Jan 06 15:04 -0700",
-	"Monday, 02-Jan-06 15:04:05 MST",
-	"Mon, 02 Jan 2006 15:04:05 MST",
+	"02 Jan 06 15:04 -07:00",
+	"Monday, 02-Jan-06 15:04:05 -0700",
+	"Monday, 02-Jan-06 15:04:05 -07:00",
 	"Mon, 02 Jan 2006 15:04:05 -0700",
+	"Mon, 02 Jan 2006 15:04:05 -07:00",
 	"2006-01-02T00:00:00",
 	"2006-01-02T15:04:05Z07:00",
 	"2006-01-02T15:04:05Z",
@@ -47,15 +48,18 @@ var TimeFormats []string = []string{
 	"Jan _2 15:04:05.000000",
 	"Jan _2 15:04:05.000000000",
 	"_2/Jan/2006:15:04:05 -0700",
+	"_2/Jan/2006:15:04:05 -07:00",
 	"Jan 2, 2006 3:04:05 PM",
 	"Jan 2 2006 15:04:05",
 	"Jan 2 15:04:05 2006",
 	"Jan 2 15:04:05 -0700",
 	"2006-01-02 15:04:05,000 -0700",
+	"2006-01-02 15:04:05,000 -07:00",
 	"2006-01-02 15:04:05 -0700",
+	"2006-01-02 15:04:05 -07:00",
 	"2006-01-02 15:04:05-0700",
+	"2006-01-02 15:04:05-07:00",
 	"2006-01-02 15:04:05,000",
-	"2006-01-02 15:04:05 MST",
 	"2006-01-02 15:04:05",
 	"2006/01/02 15:04:05",
 	"2006/01/02",
@@ -63,6 +67,7 @@ var TimeFormats []string = []string{
 	"01/02/2006",
 	"01/02/2006 15:04:05",
 	"06-01-02 15:04:05,000 -0700",
+	"06-01-02 15:04:05,000 -07:00",
 	"06-01-02 15:04:05,000",
 	"06-01-02 15:04:05",
 	"06/01/02 15:04:05",
@@ -76,31 +81,25 @@ var TimeFormats []string = []string{
 
 type TimeTree struct {
 	formats []string
-	root    *timeNode
+	root    timeNode
 }
 
 func (tt *TimeTree) Parse(t string) (time.Time, error) {
-	tx := strings.ToLower(t)
-	cur := tt.root
+	tnv := newTimeNodeVisitor()
+	tnv.Visit(tt.root, t)
 
-	for i, r := range tx {
-		typ := tnType(r)
+	candidates := tnv.Matches()
 
-		for _, n := range cur.children {
-			if (n.ntype == timeNodeDigitOrSpace && (typ == timeNodeDigit || typ == timeNodeSpace)) ||
-				(n.ntype == typ && (typ != timeNodeLiteral || (typ == timeNodeLiteral && rune(n.value) == r))) {
-
-				cur = n
-				break
-			}
+	for _, candidate := range candidates {
+		t, err := time.Parse(candidate, t)
+		if _, ok := err.(*time.ParseError); ok {
+			continue
 		}
 
-		if cur.final && i == len(tx)-1 {
-			return time.Parse(tt.formats[cur.subtype], t)
-		}
+		return t, err
 	}
 
-	return time.Time{}, ErrUnknownTimeFormat
+	return time.Time{}, ErrInvalidTime
 }
 
 func (tt *TimeTree) IsTime(t string) bool {
@@ -127,26 +126,6 @@ func IsTime(t string) bool {
 	return timeTreeRoot.IsTime(t)
 }
 
-type timeNodeType int
-
-type timeNode struct {
-	ntype    timeNodeType
-	value    rune
-	final    bool
-	subtype  int
-	children []*timeNode
-}
-
-const (
-	timeNodeRoot timeNodeType = iota
-	timeNodeDigit
-	timeNodeLetter
-	timeNodeLiteral
-	timeNodeSpace
-	timeNodeDigitOrSpace
-	timeNodePlusOrMinus
-)
-
 var (
 	timeTreeRoot *TimeTree
 )
@@ -155,63 +134,436 @@ func init() {
 	timeTreeRoot = Compile(TimeFormats)
 }
 
-func buildTimeTree(formats []string) *timeNode {
-	root := &timeNode{ntype: timeNodeRoot}
-
-	for i, f := range formats {
-		tf := strings.ToLower(f)
-		parent := root
-
-		for _, r := range tf {
-			typ := tnType(r)
-
-			hasChild := false
-			var child *timeNode
-
-			for _, child = range parent.children {
-				if (child.ntype == typ && (typ != timeNodeLiteral || (typ == timeNodeLiteral && child.value == r))) ||
-					(child.ntype == timeNodeDigitOrSpace && (typ == timeNodeDigit || typ == timeNodeSpace)) {
-					hasChild = true
-					break
-				} else if child.ntype == timeNodeDigit && typ == timeNodeDigitOrSpace {
-					child.ntype = timeNodeDigitOrSpace
-					hasChild = true
-					break
-				}
-			}
-
-			if !hasChild {
-				child = &timeNode{ntype: typ, value: r}
-				parent.children = append(parent.children, child)
-			}
-
-			parent = child
-		}
-
-		parent.final = true
-		parent.subtype = i
-	}
-
-	return root
+type timeNodeVisitor struct {
+	matches map[string]struct{}
 }
 
-func tnType(r rune) timeNodeType {
-	switch {
-	case r >= '0' && r <= '9':
-		return timeNodeDigit
-	case r >= 'a' && r <= 'y':
-		return timeNodeLetter
-	case r == ' ':
-		return timeNodeSpace
-	case r == '_':
-		return timeNodeDigitOrSpace
-	case r == '+' || r == '-':
-		return timeNodePlusOrMinus
-	case r >= 'A' && r <= 'Y':
-		return timeNodeLetter
-	case r == 'z' || r == 'Z':
-		return timeNodePlusOrMinus
+func (tnv *timeNodeVisitor) Matches() []string {
+	matches := make([]string, len(tnv.matches))
+
+	i := 0
+	for m := range tnv.matches {
+		matches[i] = m
+		i++
 	}
 
-	return timeNodeLiteral
+	return matches
+}
+
+func (tnv *timeNodeVisitor) Visit(tn timeNode, t string) {
+	values := tn.Values()
+	if len(values) > 0 && len(t) == 0 {
+		for _, value := range values {
+			tnv.matches[value] = struct{}{}
+		}
+	} else {
+		for _, c := range tn.Children() {
+			c.Visit(tnv, t)
+		}
+	}
+}
+
+func newTimeNodeVisitor() *timeNodeVisitor {
+	return &timeNodeVisitor{
+		matches: make(map[string]struct{}),
+	}
+}
+
+type timeNode interface {
+	Values() []string
+	Children() []timeNode
+	Visit(tnv *timeNodeVisitor, t string)
+}
+
+type baseTimeNode struct {
+	values   []string
+	children []timeNode
+}
+
+func (tn *baseTimeNode) Values() []string {
+	return tn.values
+}
+
+func (tn *baseTimeNode) Children() []timeNode {
+	return tn.children
+}
+
+type rootTimeNode struct {
+	*baseTimeNode
+}
+
+func (rtn *rootTimeNode) Visit(tnv *timeNodeVisitor, t string) {
+	tnv.Visit(rtn, t)
+}
+
+func (rtn *rootTimeNode) String() string {
+	return fmt.Sprintf(`{RootTimeNode children=%s}`, rtn.children)
+}
+
+type digitsTimeNode struct {
+	*baseTimeNode
+
+	min, max int
+	padded   bool
+}
+
+func (dtn *digitsTimeNode) Visit(tnv *timeNodeVisitor, t string) {
+	var padded bool
+	sz := 0
+
+	for len(t) > 0 && sz < dtn.max {
+		r, l := utf8.DecodeRuneInString(t)
+		if !padded && dtn.padded && unicode.IsSpace(r) {
+			sz++
+			t = t[l:]
+
+			continue
+		} else if !unicode.IsDigit(r) {
+			return
+		}
+
+		padded = true
+
+		sz++
+		t = t[l:]
+
+		if sz >= dtn.min {
+			tnv.Visit(dtn, t)
+		}
+	}
+}
+
+func (dtn *digitsTimeNode) String() string {
+	return fmt.Sprintf(
+		`{DigitsTimeNode min=%d max=%d padded=%v children=%s values=%s}`,
+		dtn.min, dtn.max, dtn.padded, dtn.children, dtn.values,
+	)
+}
+
+type spaceTimeNode struct {
+	*baseTimeNode
+}
+
+func (stn *spaceTimeNode) Visit(tnv *timeNodeVisitor, t string) {
+	var ok bool
+
+	for len(t) > 0 {
+		r, l := utf8.DecodeRuneInString(t)
+		if !unicode.IsSpace(r) {
+			break
+		}
+
+		ok = true
+		t = t[l:]
+	}
+
+	if !ok {
+		return
+	}
+
+	tnv.Visit(stn, t)
+}
+
+func (stn *spaceTimeNode) String() string {
+	return fmt.Sprintf(`{SpaceTimeNode children=%s values=%s}`, stn.children, stn.values)
+}
+
+type zoneTimeNode struct {
+	*baseTimeNode
+
+	len int
+}
+
+func (ztn *zoneTimeNode) Visit(tnv *timeNodeVisitor, t string) {
+	sz := 0
+
+	// Could be "Z" or +/-HH:MM.
+	// +/-HH:MM.
+	r, l := utf8.DecodeRuneInString(t)
+
+	sz++
+	t = t[l:]
+
+	if r == 'Z' {
+		tnv.Visit(ztn, t)
+		return
+	} else if r != '+' && r != '-' {
+		// Not a valid zone offset.
+		return
+	}
+
+	// Now we need some digits.
+	var ok bool
+
+	for len(t) > 0 && sz < ztn.len {
+		r, l := utf8.DecodeRuneInString(t)
+		if !unicode.IsNumber(r) {
+			break
+		}
+
+		ok = true
+
+		sz++
+		t = t[l:]
+	}
+
+	if !ok {
+		return
+	}
+
+	// Now maybe we have a ':'?
+	if sz < ztn.len {
+		if len(t) == 0 || t[0] != ':' {
+			return
+		}
+
+		sz++
+		t = t[1:]
+
+		// And now we need the rest of the digits.
+		ok = false
+
+		for len(t) > 0 && sz < ztn.len {
+			r, l := utf8.DecodeRuneInString(t)
+			if !unicode.IsNumber(r) {
+				break
+			}
+
+			sz++
+			t = t[l:]
+		}
+
+		if sz < ztn.len {
+			return
+		}
+	}
+
+	tnv.Visit(ztn, t)
+}
+
+func (ztn *zoneTimeNode) String() string {
+	return fmt.Sprintf(`{ZoneTimeNode len=%d children=%s values=%s}`, ztn.len, ztn.children, ztn.values)
+}
+
+type exactTimeNode struct {
+	*baseTimeNode
+
+	expected string
+}
+
+func (etn *exactTimeNode) Visit(tnv *timeNodeVisitor, t string) {
+	if !strings.HasPrefix(t, etn.expected) {
+		return
+	}
+
+	t = t[len(etn.expected):]
+	tnv.Visit(etn, t)
+}
+
+func (etn *exactTimeNode) String() string {
+	return fmt.Sprintf(`{ExactTimeNode expected=%s children=%s values=%s}`, etn.expected, etn.children, etn.values)
+}
+
+type otherTimeNode struct {
+	*baseTimeNode
+}
+
+func (otn *otherTimeNode) Values() []string {
+	return otn.values
+}
+
+func (otn *otherTimeNode) Children() []timeNode {
+	return otn.children
+}
+
+func (otn *otherTimeNode) Visit(tnv *timeNodeVisitor, t string) {
+	var ok bool
+
+	for len(t) > 0 {
+		r, l := utf8.DecodeRuneInString(t)
+		if unicode.IsSpace(r) || unicode.IsDigit(r) {
+			break
+		}
+
+		ok = true
+		t = t[l:]
+	}
+
+	if !ok {
+		return
+	}
+
+	tnv.Visit(otn, t)
+}
+
+func (otn *otherTimeNode) String() string {
+	return fmt.Sprintf(`{OtherTimeNode children=%s values=%s}`, otn.children, otn.values)
+}
+
+func (tn *baseTimeNode) withZoneNode(len int) *baseTimeNode {
+	for _, c := range tn.children {
+		ztn, ok := c.(*zoneTimeNode)
+		if !ok {
+			continue
+		}
+
+		if ztn.len != len {
+			continue
+		}
+
+		return ztn.baseTimeNode
+	}
+
+	base := &baseTimeNode{}
+	c := &zoneTimeNode{baseTimeNode: base, len: len}
+
+	tn.children = append(tn.children, c)
+	return base
+}
+
+func (tn *baseTimeNode) withOtherNode() *baseTimeNode {
+	for _, c := range tn.children {
+		otn, ok := c.(*otherTimeNode)
+		if !ok {
+			continue
+		}
+
+		return otn.baseTimeNode
+	}
+
+	base := &baseTimeNode{}
+	c := &otherTimeNode{baseTimeNode: base}
+
+	tn.children = append(tn.children, c)
+	return base
+}
+
+func (tn *baseTimeNode) withSpaceNode() *baseTimeNode {
+	for _, c := range tn.children {
+		otn, ok := c.(*spaceTimeNode)
+		if !ok {
+			continue
+		}
+
+		return otn.baseTimeNode
+	}
+
+	base := &baseTimeNode{}
+	c := &spaceTimeNode{baseTimeNode: base}
+
+	tn.children = append(tn.children, c)
+	return base
+}
+
+func (tn *baseTimeNode) withDigitsNode(min, max int, padded bool) *baseTimeNode {
+	for _, c := range tn.children {
+		dtn, ok := c.(*digitsTimeNode)
+		if !ok {
+			continue
+		}
+
+		if dtn.min != min || dtn.max != max || dtn.padded != padded {
+			continue
+		}
+
+		return dtn.baseTimeNode
+	}
+
+	base := &baseTimeNode{}
+	c := &digitsTimeNode{
+		baseTimeNode: base,
+		min:          min,
+		max:          max,
+		padded:       padded,
+	}
+
+	tn.children = append(tn.children, c)
+	return base
+}
+
+func (tn *baseTimeNode) withFracNode(len int) *baseTimeNode {
+	return tn.withExpected(".").withDigitsNode(1, len, false)
+}
+
+func (tn *baseTimeNode) withExpected(s string) *baseTimeNode {
+	for _, c := range tn.children {
+		etn, ok := c.(*exactTimeNode)
+		if !ok {
+			continue
+		}
+
+		if etn.expected != s {
+			continue
+		}
+
+		return etn.baseTimeNode
+	}
+
+	base := &baseTimeNode{}
+	c := &exactTimeNode{
+		baseTimeNode: base,
+		expected:     s,
+	}
+
+	tn.children = append(tn.children, c)
+	return base
+}
+
+var (
+	timeNodeMatcher = regexp.MustCompile(`(?P<zone>[Z-]07(?::?00)?)|(?P<space>\s+)|(?P<year>(?:20)?06)|(?P<hour>(?:15|[0_]?3))|(?P<month>[0_]?1)|(?P<day>[0_]?2)|(?P<minute>[0_]?4)|(?P<second>[0_]?5)|(?P<frac>\.[90]+)|(?P<digit>\d+)`)
+)
+
+func buildTimeTree(formats []string) timeNode {
+	base := &baseTimeNode{}
+
+	for _, f := range formats {
+		matches := timeNodeMatcher.FindAllStringSubmatchIndex(f, -1)
+
+		// Cursor into the time tree.
+		cur := base
+
+		i := 0
+		for len(matches) > 0 {
+			if matches[0][0] > i {
+				cur = cur.withOtherNode()
+			}
+
+			for n, name := range timeNodeMatcher.SubexpNames()[1:] {
+				start := matches[0][(n+1)*2]
+				if start == -1 {
+					continue
+				}
+
+				end := matches[0][(n+1)*2+1]
+
+				switch name {
+				case "zone":
+					cur = cur.withZoneNode(end - start)
+				case "space":
+					cur = cur.withSpaceNode()
+				case "year", "digit":
+					cur = cur.withDigitsNode(end-start, end-start, false)
+				case "hour", "month", "day", "minute", "second":
+					cur = cur.withDigitsNode(1, 2, f[start] == '_')
+				case "frac":
+					cur = cur.withFracNode(end - start - 1)
+				default:
+					panic(fmt.Errorf("unknown subexpression name %s", name))
+				}
+
+				break
+			}
+
+			i = matches[0][1]
+			matches = matches[1:]
+		}
+
+		if i < len(f) {
+			cur = cur.withOtherNode()
+		}
+
+		cur.values = append(cur.values, f)
+	}
+
+	return &rootTimeNode{base}
 }

--- a/xtime/xtime_test.go
+++ b/xtime/xtime_test.go
@@ -42,7 +42,7 @@ func TestTimeFormats(t *testing.T) {
 func TestTimeFormatsIsTime(t *testing.T) {
 	for _, f := range TimeFormats {
 		tx := re2.ReplaceAllString(re1.ReplaceAllString(f, " "), "+$1")
-		require.True(t, IsTime(tx))
+		require.True(t, IsTime(tx), "for date format %s and input %s", f, tx)
 	}
 }
 
@@ -52,12 +52,13 @@ func TestKnownTimes(t *testing.T) {
 	}{
 		{"2017-03-01T23:16:37.986Z", "2017-03-01T23:16:37Z"},
 		{"2017-03-01T23:16:37.986-07:00", "2017-03-01T23:16:37-07:00"},
+		{"Tuesday, 03-Jan-06 15:04:05 -07:00", "2006-01-03T15:04:05-07:00"},
 	}
 
 	for _, tx := range times {
 		parsed, err := Parse(tx.In)
-		require.NoError(t, err)
-		require.Equal(t, tx.Out, parsed.Format(time.RFC3339))
+		require.NoError(t, err, "for input %s", tx.In)
+		require.Equal(t, tx.Out, parsed.Format(time.RFC3339), "for input %s", tx.In)
 	}
 }
 
@@ -67,7 +68,7 @@ func ExampleParse() {
 	if err != nil {
 		fmt.Println(err)
 	} else if t1.UnixNano() != t2.UnixNano() {
-		fmt.Println("%d != %d", t1.UnixNano(), t2.UnixNano())
+		fmt.Printf("%d != %d\n", t1.UnixNano(), t2.UnixNano())
 	} else {
 		fmt.Println(t2)
 	}


### PR DESCRIPTION
This change adds support for strftime-style date formats. The public interface is extended to add support for multiple compiled formats. Example usage:

```go
fs, _ := xtime.FromPOSIX(`%a, %b %d, %Y %r %z`)
pt, err := xtime.Compile(fs).Parse("Thursday, April 13, 2017 00:31:00AM -04:00")
```

Support for timezone offset abbreviations is removed, as they didn't work anyway.